### PR TITLE
Fix how the ConnextDDS version is read

### DIFF
--- a/cmake/modules/FindRTIConnextDDS.cmake
+++ b/cmake/modules/FindRTIConnextDDS.cmake
@@ -1058,6 +1058,9 @@ string(REGEX MATCH
     "${build_id_line}"
 )
 string(REGEX MATCH
+    # Double scape was added for the last digit because the CMake regex
+    # engine gets the following characters. Doing this, everything works
+    # properly
     "[0-9]+\.[0-9]+\.[0-9]+(\\.[0-9]+)?"
     RTICONNEXTDDS_VERSION
     "${CONNEXTDDS_BUILD_ID}"


### PR DESCRIPTION
Blocked by #6 


Before the change:
```
-- Found RTIConnextDDS: /home/israel/rti_connext_dds-6.1.0 (found suitable version "6.1.0_20210212", minimum required is "6.0.0") found components: core 
```

After the change:
```
-- Found RTIConnextDDS: /home/israel/rti_connext_dds-6.1.0 (found suitable version "6.1.0", minimum required is "6.0.0") found components: core 
```