### PR TITLE
Fix regex escape backlashes

### DIFF
--- a/cmake/modules/FindRTIConnextDDS.cmake
+++ b/cmake/modules/FindRTIConnextDDS.cmake
@@ -1058,10 +1058,7 @@ string(REGEX MATCH
     "${build_id_line}"
 )
 string(REGEX MATCH
-    # Double scape was added for the last digit because the CMake regex
-    # engine gets the following characters. Doing this, everything works
-    # properly
-    "[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?"
+   "[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?"
     RTICONNEXTDDS_VERSION
     "${CONNEXTDDS_BUILD_ID}"
 )


### PR DESCRIPTION
As we have in every other regular expression in the Find Package, escape all `\`