### PR TITLE
Add missing flags and rework flag/lib appending

### DIFF
--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1115,7 +1115,13 @@ if(CONNEXTDDS_ARCH MATCHES "Linux")
         "-lm"
         "-lpthread"
         "-lrt"
+        "-rdynamic"
     )
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "6.0.0")
+        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+            "-no-pie"
+        )
+    endif()
     set(CONNEXTDDS_COMPILE_DEFINITIONS
         "RTI_UNIX"
         "RTI_LINUX"
@@ -1307,8 +1313,9 @@ if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
             CMAKE_COMPILER_VERSION VERSION_GREATER "4.6.0" AND
             RTICONNEXTDDS_VERSION VERSION_LESS "6.1.0"
         )
-           set(CONNEXTDDS_EXTERNAL_LIBS
-               -Wl,--no-as-needed  ${CONNEXTDDS_EXTERNAL_LIBS})
+            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+                -Wl,--no-as-needed
+            )
         endif()
     else()
         set(RTIConnextDDS_distributed_logger_FOUND FALSE)
@@ -1495,10 +1502,9 @@ if(security_plugins IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         )
 
         # Add OpenSSL libraries to the list of CONNEXTDDS_EXTERNAL_LIBS
-        set(CONNEXTDDS_EXTERNAL_LIBS
+        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
             ${OPENSSL_SSL_LIBRARY}
             ${OPENSSL_CRYPTO_LIBRARY}
-            ${CONNEXTDDS_EXTERNAL_LIBS}
         )
 
         set(RTIConnextDDS_security_plugins_FOUND TRUE)
@@ -1517,7 +1523,9 @@ if(monitoring_libraries IN_LIST RTIConnextDDS_FIND_COMPONENTS)
 
     if(MONITORING_FOUND)
         if(CONNEXTDDS_ARCH MATCHES "Win")
-            set(CONNEXTDDS_EXTERNAL_LIBS psapi ${CONNEXTDDS_EXTERNAL_LIBS})
+            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+                psapi
+            )
         endif()
         set(RTIConnextDDS_monitoring_libraries_FOUND TRUE)
     else()

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1117,11 +1117,7 @@ if(CONNEXTDDS_ARCH MATCHES "Linux")
         "-lrt"
         "-rdynamic"
     )
-    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "6.0.0")
-        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
-            "-no-pie"
-        )
-    endif()
+
     set(CONNEXTDDS_COMPILE_DEFINITIONS
         "RTI_UNIX"
         "RTI_LINUX"
@@ -1313,8 +1309,8 @@ if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
             CMAKE_COMPILER_VERSION VERSION_GREATER "4.6.0" AND
             RTICONNEXTDDS_VERSION VERSION_LESS "6.1.0"
         )
-            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
-                -Wl,--no-as-needed
+            list(PREPEND CONNEXTDDS_EXTERNAL_LIBS
+                "-Wl,--no-as-needed"
             )
         endif()
     else()
@@ -1502,7 +1498,7 @@ if(security_plugins IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         )
 
         # Add OpenSSL libraries to the list of CONNEXTDDS_EXTERNAL_LIBS
-        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+        list(PREPEND CONNEXTDDS_EXTERNAL_LIBS
             ${OPENSSL_SSL_LIBRARY}
             ${OPENSSL_CRYPTO_LIBRARY}
         )
@@ -1523,7 +1519,7 @@ if(monitoring_libraries IN_LIST RTIConnextDDS_FIND_COMPONENTS)
 
     if(MONITORING_FOUND)
         if(CONNEXTDDS_ARCH MATCHES "Win")
-            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+            list(PREPEND CONNEXTDDS_EXTERNAL_LIBS
                 psapi
             )
         endif()


### PR DESCRIPTION

<details>
<summary>Log</summary>
<pre>
> ./logging_publisher
        Backtrace:
        #4      ./logging_publisher(WriterHistoryMemoryPlugin_addSample+0x451) [0xd0fed9]
        #5      ./logging_publisher(PRESWriterHistoryDriver_addWrite+0x45b) [0xb50d63]
        #6      ./logging_publisher(PRESPsWriter_writeInternal+0x42dd) [0xa8d767]
        #7      ./logging_publisher(DDS_DataWriter_write_w_timestamp_untyped_generalI+0x6e9) [0x7babcf]
        #8      ./logging_publisher(_ZN3rti3pub17NativeWritePolicyI7loggingvE5writeEP18DDS_DataWriterImplPKS2_PK18PRESInstanceHandlePK10DDS_Time_t+0x43) [0x5ab103]
        #9      ./logging_publisher(_ZN3rti3pub14DataWriterImplI7loggingE5writeERKS2_RKN3dds4core15TInstanceHandleINS_4core14InstanceHandleEEERKNS7_4TimeE+0x85) [0x5aaa67]
        #10     ./logging_publisher(_ZN3dds3pub10DataWriterI7loggingN3rti3pub14DataWriterImplEE5writeERKS2_RKNS_4core15TInstanceHandleINS3_4core14InstanceHandleEEERKNS9_4TimeE+0x43) [0x5a9c71]
        #11     ./logging_publisher(_Z25run_publisher_applicationjj+0x1a3) [0x5a7229]
        #12     ./logging_publisher(main+0x7f) [0x5a7395]
        #13     /usr/lib/libc.so.6(__libc_start_main+0xd5) [0x7f85b1d83b25]
        #14     ./logging_publisher(_start+0x2e) [0x5a6fce]
</pre>
</details>





Closes #20