### PR TITLE
Adds support for QNX 7.1

### DIFF
--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1205,9 +1205,9 @@ elseif(CONNEXTDDS_ARCH MATCHES "QNX7")
     endif()
 
     if(CONNEXTDDS_ARCH MATCHES "armv8")
-        list(APPEND CONNEXTDDS_COMPILE_OPTIONS "-Vgcc/5.4.0,gcc_ntoaarch64le")
+        list(APPEND CONNEXTDDS_COMPILE_OPTIONS "-Vgcc,gcc_ntoaarch64le")
     elseif(CONNEXTDDS_ARCH MATCHES "x64")
-        list(APPEND CONNEXTDDS_COMPILE_OPTIONS "-Vgcc/5.4.0,gcc_ntox86_64")
+        list(APPEND CONNEXTDDS_COMPILE_OPTIONS "-Vgcc,gcc_ntox86_64")
     endif()
 else()
     message(FATAL_ERROR


### PR DESCRIPTION

<!-- :warning: Please, try to follow the template -->

Fixes #49 

### Proposed changes

<!-- :warning: A summary of the changes in the pull-request. -->
As described in the #49 suggested solutions, removed the hard-coded compiler version.

### Comments

<!-- :warning: Anything to highlight? -->

### Logs

<!-- :warning: Add one `details` tag for each log file required.
<details>
  <summary>Log name</summary>
  <pre>
  Sample log
  with multiple
  lines
  </pre>
</details>
-->

<details>
  <summary>armv8 QNX 7.0</summary>
  <p>
luis@build-qnxbox [/home/luis/repos/connext-cmake-findpackage-test/build_70]> /opt/tools/cmake/3.12/bin/cmake .. -DCONNEXTDDS_ARCH=$CONNEXTDDS_ARCH -DCONNEXTDDS_DIR=/home/luis/RTI/rti_connext_dds-6.1.1/ -DCONNEXTDDS_OPENSSL_DIR=/home/luis/RTI/rti_connext_dds-6.1.1/third_party/openssl-1.1.1n/$CONNEXTDDS_ARCH/release/ -DCMAKE_TOOLCHAIN_FILE=/home/luis/toolchain_files/$CONNEXTDDS_ARCH.cmake
-- The C compiler identification is QCC 5.4.0
-- The CXX compiler identification is QCC 5.4.0
-- Check for working C compiler: /opt/toolchains/armv8QNX7.0.0qcc_gpp5.4.0/qnx7-host/bin//qcc
-- Check for working C compiler: /opt/toolchains/armv8QNX7.0.0qcc_gpp5.4.0/qnx7-host/bin//qcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/toolchains/armv8QNX7.0.0qcc_gpp5.4.0/qnx7-host/bin//qcc
-- Check for working CXX compiler: /opt/toolchains/armv8QNX7.0.0qcc_gpp5.4.0/qnx7-host/bin//qcc -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done

...

-- RTI Connext DDS installation directory: /home/luis/RTI/rti_connext_dds-6.1.1
-- RTI Connext DDS architecture: armv8QNX7.0.0qcc_gpp5.4.0
-- Found OpenSSL: /home/luis/RTI/rti_connext_dds-6.1.1/third_party/openssl-1.1.1n/armv8QNX7.0.0qcc_gpp5.4.0/release/lib/libcrypto.so (found version "1.1.1n")
-- Found RTIConnextDDS: /home/luis/RTI/rti_connext_dds-6.1.1 (found suitable exact version "6.1.1.4") found components:  messaging_api security_plugins routing_service monitoring_libraries distributed_logger
...

-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/repos/connext-cmake-findpackage-test/build_70
luis@build-qnxbox [/home/luis/repos/connext-cmake-findpackage-test/build_70]> cd hello_security_c/
luis@build-qnxbox [/home/luis/repos/connext-cmake-findpackage-test/build_70/hello_security_c]> make
Scanning dependencies of target certificates
[  7%] Copying certificates
[  7%] Built target certificates
Scanning dependencies of target hello_security_c_qos_c
[ 14%] Copying USER_QOS_PROFILES.xml
[ 14%] Built target hello_security_c_qos_c
[ 21%] Generating src/HelloWorld.c, src/HelloWorldPlugin.c, src/HelloWorldSupport.c, src/HelloWorld.h, src/HelloWorldPlugin.h, src/HelloWorldSupport.h, src/HelloWorld_timestamp.cmake
INFO com.rti.ndds.nddsgen.Main Running rtiddsgen version 3.1.1.4, please wait ...
INFO com.rti.ndds.nddsgen.Main Done
Scanning dependencies of target hello_security_c_subscriber_c
[ 28%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/HelloWorld_subscriber.c.o
[ 35%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/src/HelloWorld.c.o
[ 42%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/src/HelloWorldPlugin.c.o
[ 50%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/src/HelloWorldSupport.c.o
[ 57%] Linking C executable HelloWorld_subscriber
[ 57%] Built target hello_security_c_subscriber_c
Scanning dependencies of target hello_security_c_publisher_c
[ 64%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/HelloWorld_publisher.c.o
[ 71%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/src/HelloWorld.c.o
[ 78%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/src/HelloWorldPlugin.c.o
[ 85%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/src/HelloWorldSupport.c.o
[ 92%] Linking C executable HelloWorld_publisher
[100%] Built target hello_security_c_publisher_c
  </p>
</details>

<details>
  <summary>armv8 QNX 7.1</summary>
  <p>
luis@bld-qnx71 [/home/luis/repos/connext-cmake-findpackage-test/build_71]> /opt/tools/cmake/3.12/bin/cmake .. -DCONNEXTDDS_ARCH=$CONNEXTDDS_ARCH -DCONNEXTDDS_DIR=/home/luis/RTI/rti_connext_dds-6.1.1/ -DCONNEXTDDS_OPENSSL_DIR=/home/luis/RTI/rti_connext_dds-6.1.1/third_party/openssl-1.1.1n/$CONNEXTDDS_ARCH/release/ -DCMAKE_TOOLCHAIN_FILE=/home/luis/toolchain_files/$CONNEXTDDS_ARCH.cmake
-- The C compiler identification is QCC 8.3.0
-- The CXX compiler identification is QCC 8.3.0
-- Check for working C compiler: /opt/toolchains/armv8QNX7.1qcc_gpp8.3.0/qnx71-host/bin//qcc
-- Check for working C compiler: /opt/toolchains/armv8QNX7.1qcc_gpp8.3.0/qnx71-host/bin//qcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/toolchains/armv8QNX7.1qcc_gpp8.3.0/qnx71-host/bin//qcc
-- Check for working CXX compiler: /opt/toolchains/armv8QNX7.1qcc_gpp8.3.0/qnx71-host/bin//qcc -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done

...

-- RTI Connext DDS installation directory: /home/luis/RTI/rti_connext_dds-6.1.1
-- RTI Connext DDS architecture: armv8QNX7.1qcc_gpp8.3.0
-- Found OpenSSL: /home/luis/RTI/rti_connext_dds-6.1.1/third_party/openssl-1.1.1n/armv8QNX7.1qcc_gpp8.3.0/release/lib/libcrypto.so (found version "1.1.1n")
-- Found RTIConnextDDS: /home/luis/RTI/rti_connext_dds-6.1.1 (found suitable exact version "6.1.1.4") found components:  messaging_api security_plugins routing_service monitoring_libraries distributed_logger

...

-- Build files have been written to: /home/luis/repos/connext-cmake-findpackage-test/build_71
luis@bld-qnx71 [/home/luis/repos/connext-cmake-findpackage-test/build_71]> cd hello_security_c/
luis@bld-qnx71 [/home/luis/repos/connext-cmake-findpackage-test/build_71/hello_security_c]> make
Scanning dependencies of target certificates
[  7%] Copying certificates
[  7%] Built target certificates
Scanning dependencies of target hello_security_c_qos_c
[ 14%] Copying USER_QOS_PROFILES.xml
[ 14%] Built target hello_security_c_qos_c
[ 21%] Generating src/HelloWorld.c, src/HelloWorldPlugin.c, src/HelloWorldSupport.c, src/HelloWorld.h, src/HelloWorldPlugin.h, src/HelloWorldSupport.h, src/HelloWorld_timestamp.cmake
INFO com.rti.ndds.nddsgen.Main Running rtiddsgen version 3.1.1.4, please wait ...
INFO com.rti.ndds.nddsgen.Main Done
Scanning dependencies of target hello_security_c_subscriber_c
[ 28%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/HelloWorld_subscriber.c.o
[ 35%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/src/HelloWorld.c.o
[ 42%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/src/HelloWorldPlugin.c.o
[ 50%] Building C object hello_security_c/CMakeFiles/hello_security_c_subscriber_c.dir/src/HelloWorldSupport.c.o
[ 57%] Linking C executable HelloWorld_subscriber
[ 57%] Built target hello_security_c_subscriber_c
Scanning dependencies of target hello_security_c_publisher_c
[ 64%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/HelloWorld_publisher.c.o
[ 71%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/src/HelloWorld.c.o
[ 78%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/src/HelloWorldPlugin.c.o
[ 85%] Building C object hello_security_c/CMakeFiles/hello_security_c_publisher_c.dir/src/HelloWorldSupport.c.o
[ 92%] Linking C executable HelloWorld_publisher
[100%] Built target hello_security_c_publisher_c
  </p>
</details>
