### PR TITLE
Fixes unset variable for non-example-generation

### DIFF
--- a/cmake/Modules/ConnextDdsCodegen.cmake
+++ b/cmake/Modules/ConnextDdsCodegen.cmake
@@ -433,10 +433,10 @@ function(_connextdds_codegen_get_generated_file_list)
             "${path_base}.cxx"
             "${path_base}Plugin.cxx"
         )
-        set(${_CODEGEN_VAR}_HEADERS
+        set(headers
             "${path_base}.hpp"
             "${path_base}Plugin.hpp"
-            PARENT_SCOPE)
+        )
 
         if(${_CODEGEN_GENERATE_EXAMPLE})
             set(${_CODEGEN_VAR}_PUBLISHER_SOURCE


### PR DESCRIPTION
<!-- :warning: Please, try to follow the template -->

Fixes #53 

### Proposed changes

Set the `headers` variable and use it afterwards in the else block.

```cmake
        set(sources
            "${path_base}.cxx"
            "${path_base}Plugin.cxx"
        )
        set(headers
            "${path_base}.hpp"
            "${path_base}Plugin.hpp"
        )

        if(${_CODEGEN_GENERATE_EXAMPLE})
        ...
        else()
            # Set in the parent scope
            ...
            set(${_CODEGEN_VAR}_HEADERS ${headers} PARENT_SCOPE)
            ...
        endif()
```

### Comments

<!-- :warning: Anything to highlight? -->

### Logs

Adding a `message` after the `connextdds_rtiddsgen_run` call in the `ConnextDdsAddExample.cmake` script we can see the following:

<!-- :warning: Add one `details` tag for each required log file.

<details>
  <summary>Log name</summary>
  <pre>
  Sample log
  with multiple
  lines
  </pre>
</details>

-->

<details>
  <summary>Before fix</summary>
  <pre>
-- After calling `connextdds_rtiddsgen_run`
--      waitsets_CXX11_HEADERS=
--      waitsets_CXX11_SOURCES=/home/luis/comm/rticonnextdds-examples/examples/connext_dds/waitsets/c++11/build/src/waitsets.cxx;/home/luis/comm/rticonnextdds-examples/examples/connext_dds/waitsets/c++11/build/src/waitsetsPlugin.cxx
  </pre>
</details>

<details>
  <summary>After fix</summary>
  <pre>
-- After calling `connextdds_rtiddsgen_run`
--      waitsets_CXX11_HEADERS=/home/luis/comm/rticonnextdds-examples/examples/connext_dds/waitsets/c++11/build/src/waitsets.hpp;/home/luis/comm/rticonnextdds-examples/examples/connext_dds/waitsets/c++11/build/src/waitsetsPlugin.hpp
--      waitsets_CXX11_SOURCES=/home/luis/comm/rticonnextdds-examples/examples/connext_dds/waitsets/c++11/build/src/waitsets.cxx;/home/luis/comm/rticonnextdds-examples/examples/connext_dds/waitsets/c++11/build/src/waitsetsPlugin.cxx  </pre>
</details>
