### PR TITLE
Fix #65: Adds C++98 language as a clone of C++

### DIFF
--- a/cmake/Modules/ConnextDdsAddExample.cmake
+++ b/cmake/Modules/ConnextDdsAddExample.cmake
@@ -30,7 +30,8 @@ CMake targets and set the dependencies.
 ``IDL`` (required):
     Name of the IDL file (without extension).
 ``LANG`` (required):
-    Example language. Valid values are ``C``, ``C++``, ``C++03`` and ``C++11``.
+    Example language. Valid values are ``C``, ``C++``, ``C++98``, ``C++03`` and
+    ``C++11``.
 ``PREFIX``:
     Prefix name for the targets. If not present, the folder of the example name
     will be used as prefix.

--- a/cmake/Modules/ConnextDdsAddExample.cmake
+++ b/cmake/Modules/ConnextDdsAddExample.cmake
@@ -235,9 +235,11 @@ function(connextdds_add_example)
         set(subscriber_src ${${_CONNEXT_IDL}_${lang_var}_SUBSCRIBER_SOURCE})
     else()
         set(ex "c")
-        if("${_CONNEXT_LANG}" STREQUAL "C++" OR
-            "${_CONNEXT_LANG}" STREQUAL "C++03" OR
-            "${_CONNEXT_LANG}" STREQUAL "C++11")
+        if("${_CONNEXT_LANG}" STREQUAL "C++"
+            OR "${_CONNEXT_LANG}" STREQUAL "C++98"
+            OR "${_CONNEXT_LANG}" STREQUAL "C++03"
+            OR "${_CONNEXT_LANG}" STREQUAL "C++11"
+        )
             set(ex "cxx")
         endif()
 
@@ -347,7 +349,9 @@ function(connextdds_call_codegen)
     set(api "c")
     set(c_standard C_STANDARD 90)
     set(cxx_standard CXX_STANDARD 98)
-    if("${_CONNEXT_LANG}" STREQUAL "C++")
+    if("${_CONNEXT_LANG}" STREQUAL "C++"
+        OR "${_CONNEXT_LANG}" STREQUAL "C++98"
+    )
         set(api "cpp")
     elseif("${_CONNEXT_LANG}" STREQUAL "C++03")
         set(api "cpp2")
@@ -457,7 +461,9 @@ function(connextdds_add_application)
     set(api "c")
     set(c_standard C_STANDARD 90)
     set(cxx_standard CXX_STANDARD 98)
-    if("${_CONNEXT_LANG}" STREQUAL "C++")
+    if("${_CONNEXT_LANG}" STREQUAL "C++"
+        OR "${_CONNEXT_LANG}" STREQUAL "C++98"
+    )
         set(api "cpp")
     elseif("${_CONNEXT_LANG}" STREQUAL "C++03")
         set(api "cpp2")

--- a/cmake/Modules/ConnextDdsCodegen.cmake
+++ b/cmake/Modules/ConnextDdsCodegen.cmake
@@ -60,7 +60,7 @@ Arguments:
 
 ``LANG`` (mandatory)
     The language to generate source files for. Expected values are:
-    C, C++, C++03, C++11, C++/CLI, C# and Java.
+    C, C++, C++98, C++03, C++11, C++/CLI, C# and Java.
 
 ``VAR``
     Use ``VAR`` as a prefix instead of using the IDL basename to name return
@@ -369,7 +369,9 @@ function(_connextdds_codegen_get_generated_file_list)
             set(${_CODEGEN_VAR}_SUBSCRIBER_SOURCE PARENT_SCOPE)
         endif()
 
-    elseif("${_CODEGEN_LANG}" STREQUAL "C++")
+    elseif("${_CODEGEN_LANG}" STREQUAL "C++"
+        OR "${_CODEGEN_LANG}" STREQUAL "C++98"
+    )
         set(sources "${path_base}.cxx")
         set(headers "${path_base}.h")
 
@@ -402,7 +404,8 @@ function(_connextdds_codegen_get_generated_file_list)
         endif()
 
     elseif("${_CODEGEN_LANG}" STREQUAL "C#"
-            OR "${_CODEGEN_LANG}" STREQUAL "C++/CLI")
+        OR "${_CODEGEN_LANG}" STREQUAL "C++/CLI"
+    )
         set(${_CODEGEN_VAR}_SOURCES
             "${path_base}.cpp"
             "${path_base}Plugin.cpp"
@@ -428,7 +431,8 @@ function(_connextdds_codegen_get_generated_file_list)
                 PARENT_SCOPE)
         endif()
     elseif("${_CODEGEN_LANG}" STREQUAL "C++03"
-            OR "${_CODEGEN_LANG}" STREQUAL "C++11")
+        OR "${_CODEGEN_LANG}" STREQUAL "C++11"
+    )
         set(sources
             "${path_base}.cxx"
             "${path_base}Plugin.cxx"


### PR DESCRIPTION
<!-- :warning: Please, try to follow the template -->

Fixes #65

### Proposed changes

<!-- :warning: A summary of the changes in the pull-request. -->

Adds C++98 language in scripts as a clone of C++ for newer versions of Connext.

### Comments

<!-- :warning: Anything to highlight? -->

### Logs

<!-- :warning: Add one `details` tag for each required log file.

<details>
  <summary>Log name</summary>
  <pre>
  Sample log
  with multiple
  lines
  </pre>
</details>

-->
