### PR TITLE
Issue #75: Adds CDS and Persistence S. integration

### DIFF
--- a/cmake/Modules/FindRTICivetweb.cmake
+++ b/cmake/Modules/FindRTICivetweb.cmake
@@ -1,0 +1,139 @@
+# (c) 2023 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the software solely for use with RTI Connext DDS.  Licensee may
+# redistribute copies of the software provided that all such copies are
+# subject to this license. The software is provided "as is", with no warranty
+# of any type, including any warranty for fitness for any purpose. RTI is
+# under no obligation to maintain or support the software.  RTI shall not be
+# liable for any incidental or consequential damages arising out of the use or
+# inability to use the software.
+
+#[[.rst:
+.. _find_rticivetweb:
+
+FindRTIOCivetweb
+--------------
+
+Find the Civetweb libraries.
+If no RTICivetweb_ROOT is provided it will try to find the libraries in the
+Connext installation.
+
+The list of paths to search the libraries are:
+
+- ``RTICivetweb_ROOT``
+- Environment variable ``RTICivetweb_ROOT``
+- ``${CONNEXTDDS_DIR}/third_party/civetweb-<version>/${CONNEXTDDS_ARCH}/<build_mode>``
+
+Output variables related to libraries:
+
+- ``RTICivetweb_LIBRARY``: The C library.
+- ``RTICivetweb-cpp_LIBRARY``: The C++ library.
+- ``RTICivetweb::civetweb``: Imported target for C library.
+- ``RTICivetweb::civetweb-cpp``: Imported target for C++ library.
+#]]
+
+set(_civetweb_uppercase_build_mode SHARED)
+set(_civetweb_location_property IMPORTED_LOCATION)
+
+string(TOLOWER "${CMAKE_BUILD_TYPE}" _civetweb_lowercase_build_type)
+if(NOT _civetweb_lowercase_build_type)
+    set(_civetweb_lowercase_build_type "release")
+endif()
+set(_civetweb_build_type_dir_name "${_civetweb_lowercase_build_type}")
+
+if(RTICivetweb_USE_STATIC_LIBS)
+    set(_civetweb_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set(_civetweb_uppercase_build_mode STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+    if(WIN32)
+        set(_civetweb_build_type_dir_name "static_${_civetweb_build_type_dir_name}")
+        set(CMAKE_FIND_LIBRARY_SUFFIXES .lib)
+    endif()
+elseif(WIN32)
+    set(_civetweb_location_property IMPORTED_IMPLIB)
+endif()
+
+if(NOT RTICivetweb_ROOT)
+    set(_civetweb_root_hints
+        "${CONNEXTDDS_DIR}/third_party/civetweb-${PACKAGE_FIND_VERSION}/${CONNEXTDDS_ARCH}/${_civetweb_build_type_dir_name}"
+    )
+    if(NOT PACKAGE_FIND_VERSION)
+        file(GLOB _civetweb_root_paths_expanded
+            LIST_DIRECTORIES true
+            "${CONNEXTDDS_DIR}/third_party/civetweb-*/${CONNEXTDDS_ARCH}/${_civetweb_build_type_dir_name}"
+        )
+    endif()
+endif()
+
+find_path(RTICivetweb_ROOT
+    "lib/cmake/civetweb/civetweb-config.cmake"
+    HINTS
+        ${RTICivetweb_ROOT}
+        ENV RTICivetweb_ROOT
+        ${_civetweb_root_hints}
+    PATHS
+        ${_civetweb_root_paths_expanded}
+)
+
+find_library(RTICivetweb_LIBRARY
+        civetweb
+    HINTS
+        "${RTICivetweb_ROOT}/lib"
+)
+
+find_library(RTICivetweb-cpp_LIBRARY
+        civetweb-cpp
+    HINTS
+        "${RTICivetweb_ROOT}/lib"
+)
+
+mark_as_advanced(RTICivetweb_LIBRARY RTICivetweb-cpp_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(RTICivetweb
+    REQUIRED_VARS
+        RTICivetweb_LIBRARY
+        RTICivetweb-cpp_LIBRARY
+    FAIL_MESSAGE
+        "Could NOT find Civetweb, try to set the path to Civetweb root folder in the system variable RTICivetweb_ROOT"
+)
+
+if(RTICivetweb_FOUND)
+    if(NOT TARGET RTICivetweb::civetweb AND EXISTS "${RTICivetweb_LIBRARY}")
+        add_library(RTICivetweb::civetweb 
+            ${_civetweb_uppercase_build_mode}
+            IMPORTED
+        )
+        set_target_properties(RTICivetweb::civetweb PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "CIVETWEB_DLL_IMPORTS"
+            INTERFACE_LINK_LIBRARIES "-lpthread;-ldl"
+            ${_civetweb_location_property} "${RTICivetweb_LIBRARY}"
+            IMPORTED_NO_SONAME TRUE
+        )
+    endif()
+    if(NOT TARGET RTICivetweb::civetweb-cpp AND EXISTS "${RTICivetweb-cpp_LIBRARY}")
+        add_library(RTICivetweb::civetweb-cpp
+            ${_civetweb_uppercase_build_mode}
+            IMPORTED
+        )
+        set_target_properties(RTICivetweb::civetweb-cpp PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "CIVETWEB_CXX_DLL_IMPORTS"
+            INTERFACE_LINK_LIBRARIES "RTICivetweb::civetweb"
+            ${_civetweb_location_property} "${RTICivetweb-cpp_LIBRARY}"
+            IMPORTED_NO_SONAME TRUE
+        )
+    endif()
+endif()
+
+# Restore the original find library ordering
+if(civetweb_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES
+        ${_civetweb_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES}
+    )
+endif()
+
+unset(_civetweb_uppercase_build_mode)
+unset(_civetweb_location_property)
+unset(_civetweb_lowercase_build_type)
+unset(_civetweb_build_type_dir_name)

--- a/cmake/Modules/FindRTICivetweb.cmake
+++ b/cmake/Modules/FindRTICivetweb.cmake
@@ -12,7 +12,7 @@
 #[[.rst:
 .. _find_rticivetweb:
 
-FindRTIOCivetweb
+FindRTICivetweb
 --------------
 
 Find the Civetweb libraries.

--- a/cmake/Modules/FindRTICivetweb.cmake
+++ b/cmake/Modules/FindRTICivetweb.cmake
@@ -16,8 +16,8 @@ FindRTIOCivetweb
 --------------
 
 Find the Civetweb libraries.
-If no RTICivetweb_ROOT is provided it will try to find the libraries in the
-Connext installation.
+If no RTICivetweb_ROOT is provided, FindRTICivetweb will try to find the
+Civetweb libraries in the Connext installation.
 
 The list of paths to search the libraries are:
 
@@ -25,7 +25,7 @@ The list of paths to search the libraries are:
 - Environment variable ``RTICivetweb_ROOT``
 - ``${CONNEXTDDS_DIR}/third_party/civetweb-<version>/${CONNEXTDDS_ARCH}/<build_mode>``
 
-Output variables related to libraries:
+The output variables related to the Civetweb libraries are:
 
 - ``RTICivetweb_LIBRARY``: The C library.
 - ``RTICivetweb-cpp_LIBRARY``: The C++ library.
@@ -96,7 +96,7 @@ find_package_handle_standard_args(RTICivetweb
         RTICivetweb_LIBRARY
         RTICivetweb-cpp_LIBRARY
     FAIL_MESSAGE
-        "Could NOT find Civetweb, try to set the path to Civetweb root folder in the system variable RTICivetweb_ROOT"
+        "Could not find Civetweb, try to set the path to Civetweb root folder in the system variable RTICivetweb_ROOT"
 )
 
 if(RTICivetweb_FOUND)

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -2403,11 +2403,11 @@ if(RTIConnextDDS_FOUND)
 
     # Cloud Discovery Service CPP libraries are the C libraries + the CPP API
     create_connext_imported_target(
-        TARGET "cloud_discovery_service_cpp"
-        VAR "CLOUD_DISCOVERY_SERVICE_API_CPP"
+        TARGET "cloud_discovery_service_cpp2"
+        VAR "CLOUD_DISCOVERY_SERVICE_API_C"
         DEPENDENCIES
             RTIConnextDDS::cloud_discovery_service_c
-            RTIConnextDDS::cpp_api
+            RTIConnextDDS::cpp2_api
     )
 
     # Persistence Service C API

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -2479,6 +2479,9 @@ if(RTIConnextDDS_FOUND)
         TARGET "web_integration_service_cpp"
         VAR "WEB_INTEGRATION_SERVICE_API_CPP"
         DEPENDENCIES
+            RTIConnextDDS::cpp_api
+            RTIConnextDDS::apputils_c
+            RTIConnextDDS::rtisqlite
             civetweb::civetweb-cpp
     )
 endif()

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1859,7 +1859,7 @@ if(cloud_discovery_service IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         "nddscore"
         "rtidlc"
         "nddsmetp"
-        "rtimonitoring"  # TODO: rtimonitoring2???????
+        "rtimonitoring"
         "rticonnextmsgc"
     )
     get_all_library_variables("${cloud_discovery_service_api_c_libs}"

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -126,16 +126,15 @@
 #   rtiroutingservice, rtirsinfrastructure, nddscpp2, rtidlc, nddsmetp,
 #   rticonnextmsgc and rtixml2).
 # - ``RTIConnextDDS::cloud_discovery_service_c``
-#   The Cloud Discovery Service library if found (includes rtirecordingservice,
-#   rtiroutingservice, rtirsinfrastructure, nddscpp2, rtidlc, nddsmetp,
-#   rticonnextmsgc and rtixml2).
+#   The Cloud Discovery Service library if found (includes
+#   rticlouddiscoveryservice, rtiroutingservice, rtirsinfrastructure, nddscpp2,
+#   rtidlc, nddsmetp, rticonnextmsgc and rtixml2).
 # - ``RTIConnextDDS::cloud_discovery_service_cpp``
 #   The same as RTIConnextDDS::cloud_discovery_service_c but adding the CPP
 #   libraries.
 # - ``RTIConnextDDS::persistence_service_c``
-#   The C API for Persistence Service if found (includes nddsc, nddscore,
-#   rtisqlite, also rtidlc if found).
-#
+#   The C API for Persistence Service if found (includes rtipersistenceservice,
+#   nddsc, nddscore, rtisqlite, also rtidlc if found).
 # Result Variables
 # ^^^^^^^^^^^^^^^^
 # This module will set the following variables in your project:
@@ -2411,19 +2410,13 @@ if(RTIConnextDDS_FOUND)
     )
 
     # Persistence Service C API
-    set(dependencies)
-
-    if(TARGET RTIConnextDDS::distributed_logger_c)
-        list(APPEND dependencies
+    create_connext_imported_target(
+        TARGET "persistence_service_c"
+        VAR "PERSISTENCE_SERVICE_API_C"
+        DEPENDENCIES
             RTIConnextDDS::distributed_logger_c
-        )
-    endif()
-
-    if(TARGET RTIConnextDDS::rtisqlite)
-        list(APPEND dependencies
             RTIConnextDDS::rtisqlite
         )
-    endif()
 
     create_connext_imported_target(
         TARGET "persistence_service_c"

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1426,8 +1426,8 @@ endif()
 #####################################################################
 # Distributed Logger Component Variables                            #
 #####################################################################
-# Routing Service depends on Distributed Logger and Recording Service in
-# Routing Service. Also Cloud Discovery Service depends on Routing Service.
+# Routing Service depends on Distributed Logger. Both Recording Service and
+# Cloud Discovery Service depend on Routing Service.
 if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR cloud_discovery_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR routing_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
@@ -1474,8 +1474,8 @@ endif()
 #####################################################################
 # Messaging Component Variables                                     #
 #####################################################################
-# Routing Service depends on the Messaging API and Recording Service depends
-# on Routing Service. Also Cloud Discovery Service depends on Routing Service.
+# Routing Service depends on the Messaging API. Both Recording Service and
+# Cloud Discovery Service depend on Routing Service.
 if(messaging_api IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR cloud_discovery_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR routing_service IN_LIST RTIConnextDDS_FIND_COMPONENTS

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -454,7 +454,7 @@ option(CONNEXTDDS_IMPORTED_TARGETS_DEBUG
 )
 option(CONNEXT_USE_GLOBAL_BUILD_TYPE
     "Enforce the Connext libraries build type speficied by the global\
- CMAKE_BUILD_TYPE variable" 
+ CMAKE_BUILD_TYPE variable"
     OFF
 )
 set(CONNEXTDDS_LOG_LEVEL
@@ -1432,6 +1432,7 @@ if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR cloud_discovery_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR routing_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
     OR recording_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
+    OR persistence_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
 )
 
     # Find all flavors of rtidlc
@@ -1866,7 +1867,7 @@ if(cloud_discovery_service IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         "CLOUD_DISCOVERY_SERVICE_API_C"
     )
 
-    if(CLOUD_DISCOVERY_SERVICE_API_C) # AND CLOUD_DISCOVERY_SERVICE_API_CPP_FOUND)
+    if(CLOUD_DISCOVERY_SERVICE_API_C_FOUND)
         set(RTIConnextDDS_cloud_discovery_service_FOUND TRUE)
     else()
         set(RTIConnextDDS_cloud_discovery_service_FOUND FALSE)
@@ -1879,6 +1880,7 @@ endif()
 
 if(persistence_service IN_LIST RTIConnextDDS_FIND_COMPONENTS)
     set(persistence_service_api_c_libs
+        "rtipersistenceservice"
         "nddsc"
         "nddscore"
         "rtidlc"
@@ -1889,7 +1891,7 @@ if(persistence_service IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         "PERSISTENCE_SERVICE_API_C"
     )
 
-    if(PERSISTENCE_SERVICE_API_C)
+    if(PERSISTENCE_SERVICE_API_C_FOUND)
         set(RTIConnextDDS_persistence_service_FOUND TRUE)
     else()
         set(RTIConnextDDS_persistence_service_FOUND FALSE)
@@ -2414,6 +2416,12 @@ if(RTIConnextDDS_FOUND)
     if(TARGET RTIConnextDDS::distributed_logger_c)
         list(APPEND dependencies
             RTIConnextDDS::distributed_logger_c
+        )
+    endif()
+
+    if(TARGET RTIConnextDDS::rtisqlite)
+        list(APPEND dependencies
+            RTIConnextDDS::rtisqlite
         )
     endif()
 

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -33,6 +33,7 @@
 # - recording_service
 # - cloud_discovery_service
 # - persistence_service
+# - web_integration_service
 # - low_bandwidth_plugins
 # - rtizrtps
 #
@@ -135,9 +136,9 @@
 # - ``RTIConnextDDS::persistence_service_c``
 #   The C API for Persistence Service if found (includes rtipersistenceservice,
 #   nddsc, nddscore, rtisqlite, also rtidlc if found).
-# - ``RTIConnextDDS::web_integration_service_cpp``
-#   The CPP API for Web Integration Service if found (rtiwebintegrationservice,
-#   nddscore, nddsc, nddscpp, rtiapputilsc, rtisqlite if found).
+# - ``RTIConnextDDS::web_integration_service_cpp2``
+#   The CPP2 API for Web Integration Service if found (rtiwebintegrationservice,
+#   nddscore, nddsc, nddscpp, nddscpp2, rtiapputilsc, rtisqlite if found).
 # Result Variables
 # ^^^^^^^^^^^^^^^^
 # This module will set the following variables in your project:
@@ -263,8 +264,8 @@
 #     (e.g., ``PERSISTENCE_SERVICE_API_C_LIBRARIES_RELEASE_STATIC``)
 #
 # - ``web_integration_service`` component:
-#   - ``WEB_INTEGRATION_SERVICE_API_CPP``
-#     (e.g., ``WEB_INTEGRATION_SERVICE_API_CPP_LIBRARIES_RELEASE_STATIC``)
+#   - ``WEB_INTEGRATION_SERVICE_API_CPP2``
+#     (e.g., ``WEB_INTEGRATION_SERVICE_API_CPP2_LIBRARIES_RELEASE_STATIC``)
 
 # - ``low_bandwidth_plugins`` component:
 #   - ``LOW_BANDWIDTH_DISCOVERY_STATIC``
@@ -1909,48 +1910,29 @@ endif()
 #####################################################################
 
 if(web_integration_service IN_LIST RTIConnextDDS_FIND_COMPONENTS)
-
-    set(web_integration_service_api_cpp_libs
+    set(web_integration_service_api_cpp2_libs
         "rtiwebintegrationservice"
         "nddscore"
         "nddsc"
         "nddscpp"
+        "nddscpp2"
         "rtiapputilsc"
         "rtisqlite"
     )
-    get_all_library_variables("${web_integration_service_api_cpp_libs}"
-        "WEB_INTEGRATION_SERVICE_API_CPP"
+    get_all_library_variables("${web_integration_service_api_cpp2_libs}"
+        "WEB_INTEGRATION_SERVICE_API_CPP2"
     )
 
-    if(WEB_INTEGRATION_SERVICE_API_CPP_FOUND)
-        string(TOLOWER "${CMAKE_BUILD_TYPE}" _lower_build_mode)
-        file(GLOB _civetweb_config_dir_list
-            LIST_DIRECTORIES TRUE
-            "${CONNEXTDDS_DIR}/third_party/civetweb-*/${CONNEXTDDS_ARCH}/${_lower_build_mode}/lib/cmake/civetweb/"
-        )
-        list(GET _civetweb_config_dir_list 0 civetweb_DIR)
-        connextdds_log_debug("civetweb CMake config dir: ${civetweb_DIR}")
-        find_package(civetweb REQUIRED CONFIG)
-
-        # Add civetweb include directories to the list of CONNEXTDDS_INCLUDE_DIRS
-        list(APPEND CONNEXTDDS_INCLUDE_DIRS
-            "${civetweb_INCLUDE_DIR}"
-        )
+    if(WEB_INTEGRATION_SERVICE_API_CPP2_FOUND)
+        find_package(RTICivetweb REQUIRED)
 
         # Add civetweb library to the list of CONNEXTDDS_EXTERNAL_LIBS
-        string(TOUPPER "${CMAKE_BUILD_TYPE}" _upper_build_mode)
-        get_target_property(civetweb_library civetweb::civetweb-cpp IMPORTED_LOCATION_${_upper_build_mode})
-        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
-            ${civetweb_library}
-        )
-        unset(_lower_build_mode)
-        unset(_upper_build_mode)
+        list(APPEND CONNEXTDDS_EXTERNAL_LIBS "${RTICivetweb-cpp_LIBRARY}")
 
         set(RTIConnextDDS_web_integration_service_FOUND TRUE)
     else()
         set(RTIConnextDDS_web_integration_service_FOUND FALSE)
     endif()
-
 endif()
 
 #####################################################################
@@ -2476,12 +2458,13 @@ if(RTIConnextDDS_FOUND)
 
     # Web Integration Service CPP API
     create_connext_imported_target(
-        TARGET "web_integration_service_cpp"
-        VAR "WEB_INTEGRATION_SERVICE_API_CPP"
+        TARGET "web_integration_service_cpp2"
+        VAR "WEB_INTEGRATION_SERVICE_API_CPP2"
         DEPENDENCIES
             RTIConnextDDS::cpp_api
+            RTIConnextDDS::cpp2_api
             RTIConnextDDS::apputils_c
             RTIConnextDDS::rtisqlite
-            civetweb::civetweb-cpp
+            RTICivetweb::civetweb-cpp
     )
 endif()


### PR DESCRIPTION
Added the components cloud_discovery_service, persistence_service and web_integration_service and their respective imported targets.

<!-- :warning: Please, try to follow the template -->

Fixes #75
Fixes #79 

### Proposed changes

Added two new components:

- `cloud_discovery_service`
- `persistence_service`
- `web_integration_service`

And their respective imported targets associated: 

- `RTIConnextDDS::cloud_discovery_service_c` and `RTIConnextDDS::cloud_discovery_service_cpp2`
- `RTIConnextDDS::persistence_service_c`
- `RTIConnextDDS::web_integration_service_cpp2`

### Comments

<!-- :warning: Anything to highlight? -->

- [x] ~Waiting for Persistence Service example for the testing.~
  https://github.com/rticommunity/rticonnextdds-examples/pull/568/
- [x] ~Waiting for Cloud Discovery Service example for the testing.~
  https://github.com/rticommunity/rticonnextdds-examples/pull/573
- [x] ~Are we missing the [`rtimonitoring2` imported target](https://github.com/rticommunity/rticonnextdds-cmake-utils/commit/2b4ba2bd1ca6ae87363dd0934a18f6bf45b7468e#diff-70ac52d42c16dd8a28492615a0aea64bcd83c76eb5107b28c74384cf9d540cbbR1862) too? After checking the `ldd librticlouddiscoveryservice.so`~: 
  <details><summary><del>ldd command</del></summary><pre>
  $ ldd $CONNEXTDDS_DIR/lib/x64Linux4gcc7.3.0/librticlouddiscoveryservice.so
  ...
  librtimonitoring2.so => ...
  ...
  </pre></details>
  Edit: We are using rtimonitoring for this feature release.
- [x] ~Waiting for Web Integration Service example for the testing.~ https://github.com/rticommunity/rticonnextdds-examples/pull/575


### Logs

<!-- :warning: Add one `details` tag for each required log file.

<details>
  <summary>Log name</summary>
  <pre>
  Sample log
  with multiple
  lines
  </pre>
</details>

-->

<details>
  <summary>Persistence Service C (static)</summary>
  <pre>
> rm -r ./*; cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_VERBOSE_MAKEFILE=1 && make VERBOSE=1
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- RTI Connext DDS installation directory: /home/luis/ndds/rti_connext_dds-7.1.0
-- RTI Connext DDS architecture: x64Linux4gcc7.3.0
-- Found RTIConnextDDS: /home/luis/ndds/rti_connext_dds-7.1.0 (found suitable version "7.1.0.0", minimum required is "7.0.0") found components:  core persistence_service
-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build
/opt/tools/cmake/3.12/bin/cmake -H/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c -B/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
make -f CMakeFiles/PersistenceServiceLibraryAPIC.dir/build.make CMakeFiles/PersistenceServiceLibraryAPIC.dir/depend
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
cd /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build && /opt/tools/cmake/3.12/bin/cmake -E cmake_depends "Unix Makefiles" /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/DependInfo.cmake --color=
Dependee "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/DependInfo.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/depend.internal".
Dependee "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/depend.internal".
Scanning dependencies of target PersistenceServiceLibraryAPIC
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
make -f CMakeFiles/PersistenceServiceLibraryAPIC.dir/build.make CMakeFiles/PersistenceServiceLibraryAPIC.dir/build
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
[ 50%] Building C object CMakeFiles/PersistenceServiceLibraryAPIC.dir/persistence_service_library_api.c.o
/opt/tools/gcc/8.5.0/bin/gcc -DRTI_64BIT -DRTI_LINUX -DRTI_STATIC -DRTI_UNIX -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds/hpp   -o CMakeFiles/PersistenceServiceLibraryAPIC.dir/persistence_service_library_api.c.o   -c /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/persistence_service_library_api.c
[100%] Linking C executable PersistenceServiceLibraryAPIC
/opt/tools/cmake/3.12/bin/cmake -E cmake_link_script CMakeFiles/PersistenceServiceLibraryAPIC.dir/link.txt --verbose=1
/opt/tools/gcc/8.5.0/bin/gcc    CMakeFiles/PersistenceServiceLibraryAPIC.dir/persistence_service_library_api.c.o  -o PersistenceServiceLibraryAPIC /home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0/librtipersistenceservicez.a /home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0/librtidlcz.a /home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0/librtisqlitez.a /home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0/libnddscz.a /home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0/libnddscorez.a -ldl -lm -lpthread -lrt -rdynamic
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
[100%] Built target PersistenceServiceLibraryAPIC
make[1]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles 0
  </pre>
</details>

<details>
  <summary>Persistent Service C (dynamic)</summary>
  <pre>
[ ~/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build ] [ rticonnextdds-examples@feature/#567 ]
> rm -r ./*; cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=1 && make VERBOSE=1
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- RTI Connext DDS installation directory: /home/luis/ndds/rti_connext_dds-7.1.0
-- RTI Connext DDS architecture: x64Linux4gcc7.3.0
-- Found RTIConnextDDS: /home/luis/ndds/rti_connext_dds-7.1.0 (found suitable version "7.1.0.0", minimum required is "7.0.0") found components:  core persistence_service
-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build
/opt/tools/cmake/3.12/bin/cmake -H/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c -B/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
make -f CMakeFiles/PersistenceServiceLibraryAPIC.dir/build.make CMakeFiles/PersistenceServiceLibraryAPIC.dir/depend
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
cd /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build && /opt/tools/cmake/3.12/bin/cmake -E cmake_depends "Unix Makefiles" /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/DependInfo.cmake --color=
Dependee "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/DependInfo.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/depend.internal".
Dependee "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles/PersistenceServiceLibraryAPIC.dir/depend.internal".
Scanning dependencies of target PersistenceServiceLibraryAPIC
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
make -f CMakeFiles/PersistenceServiceLibraryAPIC.dir/build.make CMakeFiles/PersistenceServiceLibraryAPIC.dir/build
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
[ 50%] Building C object CMakeFiles/PersistenceServiceLibraryAPIC.dir/persistence_service_library_api.c.o
/opt/tools/gcc/8.5.0/bin/gcc -DRTI_64BIT -DRTI_LINUX -DRTI_UNIX -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds/hpp   -o CMakeFiles/PersistenceServiceLibraryAPIC.dir/persistence_service_library_api.c.o   -c /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/persistence_service_library_api.c
[100%] Linking C executable PersistenceServiceLibraryAPIC
/opt/tools/cmake/3.12/bin/cmake -E cmake_link_script CMakeFiles/PersistenceServiceLibraryAPIC.dir/link.txt --verbose=1
/opt/tools/gcc/8.5.0/bin/gcc    CMakeFiles/PersistenceServiceLibraryAPIC.dir/persistence_service_library_api.c.o  -o PersistenceServiceLibraryAPIC  -L/home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0 -Wl,-rpath,/home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0 -lrtipersistenceservice -lrtidlc -lrtisqlite -lnddsc -lnddscore -ldl -lm -lpthread -lrt -rdynamic
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
[100%] Built target PersistenceServiceLibraryAPIC
make[1]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build'
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/persistence_service/library_api/c/build/CMakeFiles 0
  </pre>
</details>

<details>
  <summary>Cloud Discovery Service C</summary>
  <pre>
[ ~/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build ] [ rticonnextdds-examples@feature/#569 ]
> rm -r ./*; cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=1 && make VERBOSE=1
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- RTI Connext DDS installation directory: /home/luis/ndds/rti_connext_dds-7.1.0
-- RTI Connext DDS architecture: x64Linux4gcc7.3.0
-- Found RTIConnextDDS: /home/luis/ndds/rti_connext_dds-7.1.0 (found suitable version "7.1.0.0", minimum required is "7.0.0") found components:  core cloud_discovery_service
-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build
/opt/tools/cmake/3.12/bin/cmake -H/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c -B/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build'
make -f CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/build.make CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/depend
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build'
cd /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build && /opt/tools/cmake/3.12/bin/cmake -E cmake_depends "Unix Makefiles" /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/DependInfo.cmake --color=
Dependee "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/DependInfo.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/depend.internal".
Dependee "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/depend.internal".
Scanning dependencies of target CloudDiscoveryServiceLibraryAPIC
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build'
make -f CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/build.make CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/build
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build'
[ 50%] Building C object CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/cloud_discovery_service_library_api.c.o
/opt/tools/gcc/8.5.0/bin/gcc -DRTI_64BIT -DRTI_LINUX -DRTI_UNIX -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds/hpp   -o CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/cloud_discovery_service_library_api.c.o   -c /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/cloud_discovery_service_library_api.c
[100%] Linking C executable CloudDiscoveryServiceLibraryAPIC
/opt/tools/cmake/3.12/bin/cmake -E cmake_link_script CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/link.txt --verbose=1
/opt/tools/gcc/8.5.0/bin/gcc    CMakeFiles/CloudDiscoveryServiceLibraryAPIC.dir/cloud_discovery_service_library_api.c.o  -o CloudDiscoveryServiceLibraryAPIC  -L/home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0 -Wl,-rpath,/home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0 -lrticlouddiscoveryservice -lrtiroutingservice -lrtirsinfrastructure -lrtidlc -lnddsmetp -lrticonnextmsgc -lrtixml2 -lrtiapputilsc -lnddsc -lnddscore -ldl -lm -lpthread -lrt -rdynamic
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build'
[100%] Built target CloudDiscoveryServiceLibraryAPIC
make[1]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build'
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c/build/CMakeFiles 0

  </pre>
</details>

<details>
  <summary>Cloud Discovery Service CXX11</summary>
  <pre>
[ ~/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build ] [ rticonnextdds-examples@feature/#569 ]
> rm -r ./*; cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=1 && make VERBOSE=1
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- RTI Connext DDS installation directory: /home/luis/ndds/rti_connext_dds-7.1.0
-- RTI Connext DDS architecture: x64Linux4gcc7.3.0
-- Found RTIConnextDDS: /home/luis/ndds/rti_connext_dds-7.1.0 (found suitable version "7.1.0.0", minimum required is "7.0.0") found components:  core cloud_discovery_service
-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build
/opt/tools/cmake/3.12/bin/cmake -H/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11 -B/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build'
make -f CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/build.make CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/depend
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build'
cd /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build && /opt/tools/cmake/3.12/bin/cmake -E cmake_depends "Unix Makefiles" /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11 /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11 /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/DependInfo.cmake --color=
Dependee "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/DependInfo.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/depend.internal".
Dependee "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/depend.internal".
Scanning dependencies of target CloudDiscoveryServiceLibraryAPICXX11
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build'
make -f CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/build.make CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/build
make[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build'
[ 50%] Building CXX object CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/cloud_discovery_service_library_api.cxx.o
/opt/tools/gcc/8.5.0/bin/g++  -DRTI_64BIT -DRTI_LINUX -DRTI_UNIX -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds -isystem /home/luis/ndds/rti_connext_dds-7.1.0/include/ndds/hpp  -std=gnu++11 -o CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/cloud_discovery_service_library_api.cxx.o -c /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/cloud_discovery_service_library_api.cxx
[100%] Linking CXX executable CloudDiscoveryServiceLibraryAPICXX11
/opt/tools/cmake/3.12/bin/cmake -E cmake_link_script CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/link.txt --verbose=1
/opt/tools/gcc/8.5.0/bin/g++     CMakeFiles/CloudDiscoveryServiceLibraryAPICXX11.dir/cloud_discovery_service_library_api.cxx.o  -o CloudDiscoveryServiceLibraryAPICXX11  -L/home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0 -Wl,-rpath,/home/luis/ndds/rti_connext_dds-7.1.0/lib/x64Linux4gcc7.3.0 -lrticlouddiscoveryservice -lrticlouddiscoveryservice -lrtiroutingservice -lrtirsinfrastructure -lrtidlc -lnddsmetp -lrticonnextmsgc -lrtixml2 -lrtiapputilsc -lnddscpp2 -lnddsc -lnddscore -ldl -lm -lpthread -lrt -rdynamic
make[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build'
[100%] Built target CloudDiscoveryServiceLibraryAPICXX11
make[1]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build'
/opt/tools/cmake/3.12/bin/cmake -E cmake_progress_start /home/luis/comm/rticonnextdds-examples/examples/cloud_discovery_service/library_api/c++11/build/CMakeFiles 0

  </pre>
</details>

<details>
  <summary>Web Integration Service CXX11</summary>
  <pre>
> cmake ..
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- RTI Connext DDS installation directory: /home/luis/ndds/rti_connext_dds-7.1.0
-- RTI Connext DDS architecture: x64Linux4gcc7.3.0
-- Found RTICivetweb: /home/luis/ndds/rti_connext_dds-7.1.0/third_party/civetweb-1.15/x64Linux4gcc7.3.0/release/lib/libcivetweb.so  
-- Found RTIConnextDDS: /home/luis/ndds/rti_connext_dds-7.1.0 (found suitable version "7.1.0.0", minimum required is "7.0.0") found components:  core web_integration_service 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build
[ 16:08 ] [ ~/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build ] [ rticonnextdds-examples@feature/#574 ]
> cmake --build .
gmake[1]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build'
gmake[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build'
Scanning dependencies of target WebIntegrationServiceLibraryAPICXX11
gmake[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build'
gmake[2]: Entering directory '/home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build'
[ 50%] Building CXX object CMakeFiles/WebIntegrationServiceLibraryAPICXX11.dir/web_integration_service_library_api.cxx.o
[100%] Linking CXX executable WebIntegrationServiceLibraryAPICXX11
gmake[2]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build'
[100%] Built target WebIntegrationServiceLibraryAPICXX11
gmake[1]: Leaving directory '/home/luis/comm/rticonnextdds-examples/examples/web_integration_service/library_api/build'
  </pre>
</details>