### PR TITLE
Add parent scope to the <LIBRARY_NAME>_LIBRARIES variable in FindRTIConnextDDS (issue #77)

### DIFF
--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1002,7 +1002,7 @@ function(get_all_library_variables
     endif()
 
     set(${result_var_name}_LIBRARIES
-        ${result_var_name}_LIBRARIES_${build_mode}_${link_mode})
+        ${result_var_name}_LIBRARIES_${build_mode}_${link_mode} PARENT_SCOPE)
     connextdds_log_debug(
         "\t${result_var_name}_LIBRARIES=${${result_var_name}_LIBRARIES}"
     )


### PR DESCRIPTION
Fixes #77

### Proposed changes

Adds PARENT_SCOPE
