### PR TITLE
Add the new components and imported targets for the test framework

### DIFF
--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -20,6 +20,8 @@
 # This module sets variables for the following components that are part of RTI
 # Connext:
 # - core (default, always provided)
+# - test
+# - test_helpers
 # - distributed_logger
 # - messaging_api
 # - routing_service
@@ -69,6 +71,11 @@
 #   The APP Utils C library (rtiapputils).
 # - ``RTIConnextDDS::rtisqlite``.
 #   The RTI SQLite library (rtisqlite).
+# - ``RTIConnextDDS::test``.
+#   The RTI Test Framework library (rtitest).
+# - ``RTIConnextDDS::test_helpers``.
+#   The RTI Test Framework helpers libraries (includes nddsctesthelpers,
+#   nddsctransporttesthelpers, rtitest, and nddsc)
 # - ``RTIConnextDDS::distributed_logger_c``
 #   The C API library for Distributed Logger if found.
 # - ``RTIConnextDDS::distributed_logger_cpp``
@@ -202,6 +209,14 @@
 #     (e.g., ``RTIAPPUTILS_C_LIBRARIES_RELEASE_STATIC``)
 #   - ``RTISQLITE``
 #     (e.g., ``RTISQLITE_LIBRARIES_RELEASE_STATIC``)
+#
+# - ``test`` component:
+#   - ``RTITEST``
+#     (e.g., ``RTITEST_LIBRARIES_RELEASE_STATIC``)
+#
+# - ``test_helpers`` component:
+#   - ``NDDS_TEST_HELPERS``
+#     (e.g., ``NDDS_TEST_HELPERS_LIBRARIES_RELEASE_STATIC``)
 #
 # - ``distributed_loger`` component:
 #   - ``DISTRIBUTED_LOGGER_C``
@@ -1472,6 +1487,50 @@ else()
 endif()
 
 #####################################################################
+# RTI Test Framework Component Variables                            #
+#####################################################################
+if(test IN_LIST RTIConnextDDS_FIND_COMPONENTS
+    OR test_helpers IN_LIST RTIConnextDDS_FIND_COMPONENTS
+)
+    # Find all flavors of rtitest
+    set(rtitest_libs "rtitest")
+    get_all_library_variables("${rtitest_libs}"
+        "RTITEST"
+    )
+
+    set(RTIConnextDDS_test_FOUND FALSE)
+    if(RTITEST_FOUND)
+        set(RTIConnextDDS_test_FOUND TRUE)
+        list(APPEND CONNEXTDDS_INCLUDE_DIRS
+            "/home/luis/rti/connextdds/connextdds/test.1.0/include/"
+        )
+    endif()
+endif()
+
+#####################################################################
+# RTI Test Framework Helpers Component Variables                    #
+#####################################################################
+
+if(test_helpers IN_LIST RTIConnextDDS_FIND_COMPONENTS)
+    # Find all flavors of test_helpers
+    set(ndds_test_helpers_libs
+        "nddsctesthelpers"
+        "nddsctransporttesthelpers"
+        "nddscore"
+        "nddsc"
+        "rtitest"
+    )
+    get_all_library_variables("${ndds_test_helpers_libs}"
+        "NDDS_TEST_HELPERS"
+    )
+
+    set(RTIConnextDDS_test_helpers_FOUND FALSE)
+    if(NDDS_TEST_HELPERS_FOUND)
+        set(RTIConnextDDS_test_helpers_FOUND TRUE)
+    endif()
+endif()
+
+#####################################################################
 # Distributed Logger Component Variables                            #
 #####################################################################
 # Routing Service depends on Distributed Logger. Both Recording Service and
@@ -1519,7 +1578,6 @@ if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
     endif()
 endif()
 
-
 #####################################################################
 # Messaging Component Variables                                     #
 #####################################################################
@@ -1565,7 +1623,6 @@ if(messaging_api IN_LIST RTIConnextDDS_FIND_COMPONENTS
         set(RTIConnextDDS_messaging_api_FOUND FALSE)
     endif()
 endif()
-
 
 #####################################################################
 # Routing Service Component Variables                               #
@@ -1656,7 +1713,6 @@ if(routing_service IN_LIST RTIConnextDDS_FIND_COMPONENTS
     endif()
 
 endif()
-
 
 #####################################################################
 # Security Plugins Component Variables                              #
@@ -2119,7 +2175,6 @@ find_package_handle_standard_args(RTIConnextDDS
 #####################################################################
 # Create the imported targets                                       #
 #####################################################################
-
 if(RTIConnextDDS_FOUND)
     #################### Core and APIs imported targets #####################
     # Core
@@ -2210,6 +2265,21 @@ if(RTIConnextDDS_FOUND)
         VAR "RTISQLITE"
         DEPENDENCIES
             RTIConnextDDS::c_api
+    )
+
+    ######################## Test imported targets #########################
+
+    create_connext_imported_target(
+        TARGET "test"
+        VAR "RTITEST"
+    )
+
+    create_connext_imported_target(
+        TARGET "test_helpers"
+        VAR "NDDS_TEST_HELPERS"
+        DEPENDENCIES
+            RTIConnextDDS::c_api
+            RTIConnextDDS::test
     )
 
     ###################### Distributed Logger targets ######################

--- a/cmake/Modules/FindRTIConnextDDS.cmake
+++ b/cmake/Modules/FindRTIConnextDDS.cmake
@@ -1501,9 +1501,6 @@ if(test IN_LIST RTIConnextDDS_FIND_COMPONENTS
     set(RTIConnextDDS_test_FOUND FALSE)
     if(RTITEST_FOUND)
         set(RTIConnextDDS_test_FOUND TRUE)
-        list(APPEND CONNEXTDDS_INCLUDE_DIRS
-            "/home/luis/rti/connextdds/connextdds/test.1.0/include/"
-        )
     endif()
 endif()
 


### PR DESCRIPTION
<!-- :warning: Please, try to follow the template -->

Fixes #95 

### Proposed changes

Added the following components:

- `test`: This component will enable the imported target `RTIConnextDDS::test`
- `test_helpers`: This component will enable the imported target `RTIConnextDDS::test_helpers`

### Comments

<!-- :warning: Anything to highlight? -->

### Logs

<!-- :warning: Add one `details` tag for each required log file.

<details>
  <summary>Log name</summary>
  <pre>
  Sample log
  with multiple
  lines
  </pre>
</details>

-->

<details>
  <summary>Test build and execution</summary>
  <pre>
$ rm -r ./*; cmake -DCONNEXTDDS_DIR=/home/luis/ndds/rti_connext_dds-7.1.0/ .. && cmake --build . 
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc
-- Check for working C compiler: /opt/tools/gcc/8.5.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++
-- Check for working CXX compiler: /opt/tools/gcc/8.5.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- RTI Connext installation directory: /home/luis/ndds/rti_connext_dds-7.1.0
-- RTI Connext architecture: x64Linux4gcc7.3.0
-- Found RTIConnextDDS: /home/luis/ndds/rti_connext_dds-7.1.0 (found suitable version "7.1.0.0", minimum required is "7.1.0") found components:  test test_helpers 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build
gmake[1]: Entering directory '/home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build'
gmake[2]: Entering directory '/home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build'
Scanning dependencies of target test
gmake[2]: Leaving directory '/home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build'
gmake[2]: Entering directory '/home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build'
[ 50%] Building C object CMakeFiles/test.dir/rtitest.c.o
[100%] Linking C executable test
gmake[2]: Leaving directory '/home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build'
[100%] Built target test
gmake[1]: Leaving directory '/home/luis/comm/lulivi-rticonnextdds-cmake-utils/test_framework/build'


  $ ./test
  tester:?
  tester:test[0]?
  test1:?
  Test setup is not initialized, please call RTITestSetting_setupWithConnext or RTITestSetting_setupStandalone from your tester
  tester:test[0] failed!!!!!!!!!!!!!!!!!
  </pre>
</details>
