### PR TITLE
GH-102: Add distutils package

### DIFF
--- a/resources/docker/Dockerfile.x64Linux
+++ b/resources/docker/Dockerfile.x64Linux
@@ -12,7 +12,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV CONNEXTDDS_ARCH="x64Linux4gcc7.3.0"
 
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     clang \
@@ -21,6 +21,7 @@ RUN apt update && apt install -y \
     cmake \
     python3 \
     clang-tools-10 \
+    python3-distutils \
     && rm -rf /var/lib/apt/lists/*
 
 USER jenkins


### PR DESCRIPTION
<!-- :warning: Please, try to follow the template -->

Fixes #102 

### Proposed changes

Adding the python3-distutils package fixes the error found in the Docker execution of the linux_install.py script used in the Jenkins CI

<!-- :warning: A summary of the changes in the pull-request. -->

### Comments

<!-- :warning: Anything to highlight? -->

### Logs

<!-- :warning: Add one `details` tag for each required log file.

<details>
  <summary>Log name</summary>
  <pre>
  Sample log
  with multiple
  lines
  </pre>
</details>

-->
