### PR TITLE
Fix proper html code in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,12 +15,15 @@ Fixes #<issue id>
 <!-- :warning: Add one `details` tag for each required log file.
 
 <details>
-  <summary>Log name</summary>
-  <pre>
-  Sample log
-  with multiple
-  lines
-  </pre>
+
+<summary>Log name</summary>
+
+<samp>
+Sample log
+with multiple
+lines
+</samp>
+
 </details>
 
 -->


### PR DESCRIPTION


### Proposed changes

Use `samp` tag instead of `pre` tag in the log output to avoid auto formatting.